### PR TITLE
Set external art to match album image from MP3 file.

### DIFF
--- a/src/google_music/clients/musicmanager.py
+++ b/src/google_music/clients/musicmanager.py
@@ -264,6 +264,11 @@ class MusicManager(GoogleMusicClient):
 		else:
 			external_art = None
 
+		if not external_art and len(song.pictures) > 0:
+			# We did not provide an external art,
+			# so let's use the one packed into the music itself.
+			external_art = song.pictures[0].data
+
 		result = {'filepath': Path(song.filepath)}
 
 		track_info = mm_calls.Metadata.get_track_info(song)


### PR DESCRIPTION
This resolves issue #16.

Implementation: if the API call is not providing external album art, and the MP3 file has one, use the extracted ID3TagV2 metadata and get the album art content from it.